### PR TITLE
Replace dependency from fvcore with iopath

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name         = "layoutparser",
         "torch",
         "torchvision",
         "pycocotools>=2.0.2",
-        "fvcore==0.1.1.post20200623",
+        "iopath",
       ],
       extras_require={
         "ocr": [

--- a/src/layoutparser/models/catalog.py
+++ b/src/layoutparser/models/catalog.py
@@ -1,4 +1,4 @@
-from fvcore.common.file_io import PathHandler, PathManager, HTTPURLHandler
+from iopath.common.file_io import PathHandler, PathManager, HTTPURLHandler
 
 MODEL_CATALOG = {
     'HJDataset': {
@@ -77,5 +77,6 @@ class LayoutParserHandler(PathHandler):
         return PathManager.open(self._get_local_path(path), mode, **kwargs)
 
 
-PathManager.register_handler(DropboxHandler())
-PathManager.register_handler(LayoutParserHandler())
+PathManagerSingleton = PathManager()
+PathManagerSingleton.register_handler(DropboxHandler())
+PathManagerSingleton.register_handler(LayoutParserHandler())

--- a/src/layoutparser/models/layoutmodel.py
+++ b/src/layoutparser/models/layoutmodel.py
@@ -5,10 +5,8 @@ import importlib
 from PIL import Image
 import numpy as np
 import torch
-from fvcore.common.file_io import PathManager
 
-# TODO: Update to iopath in the next major release
-
+from .catalog import PathManagerSingleton
 from ..elements import *
 
 __all__ = ["Detectron2LayoutModel"]
@@ -95,7 +93,7 @@ class Detectron2LayoutModel(BaseLayoutModel):
     def __init__(self, config_path, model_path=None, label_map=None, extra_config=[]):
 
         cfg = self._config.get_cfg()
-        config_path = PathManager.get_local_path(config_path)
+        config_path = PathManagerSingleton.get_local_path(config_path)
         cfg.merge_from_file(config_path)
         cfg.merge_from_list(extra_config)
 


### PR DESCRIPTION
The used moduled of the fvcore library are available in iopath, which was extracted from fvcore.