### PR TITLE
Misc improvements

### DIFF
--- a/src/layoutparser/models/catalog.py
+++ b/src/layoutparser/models/catalog.py
@@ -1,51 +1,83 @@
 from iopath.common.file_io import PathHandler, PathManager, HTTPURLHandler
 from iopath.common.file_io import PathManager as PathManagerBase
+
 # A trick learned from https://github.com/facebookresearch/detectron2/blob/65faeb4779e4c142484deeece18dc958c5c9ad18/detectron2/utils/file_io.py#L3
 
 MODEL_CATALOG = {
-    'HJDataset': {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/6icw6at8m28a2ho/model_final.pth?dl=1',
-        'mask_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/893paxpy5suvlx9/model_final.pth?dl=1',
-        'retinanet_R_50_FPN_3x': 'https://www.dropbox.com/s/yxsloxu3djt456i/model_final.pth?dl=1'
+    "HJDataset": {
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/6icw6at8m28a2ho/model_final.pth?dl=1",
+        "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/893paxpy5suvlx9/model_final.pth?dl=1",
+        "retinanet_R_50_FPN_3x": "https://www.dropbox.com/s/yxsloxu3djt456i/model_final.pth?dl=1",
     },
     "PubLayNet": {
         "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/dgy9c10wykk4lq4/model_final.pth?dl=1",
         "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/d9fc9tahfzyl6df/model_final.pth?dl=1",
-        "mask_rcnn_X_101_32x8d_FPN_3x": "https://www.dropbox.com/s/57zjbwv6gh3srry/model_final.pth?dl=1"
+        "mask_rcnn_X_101_32x8d_FPN_3x": "https://www.dropbox.com/s/57zjbwv6gh3srry/model_final.pth?dl=1",
     },
     "PrimaLayout": {
         "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/h7th27jfv19rxiy/model_final.pth?dl=1"
     },
     "NewspaperNavigator": {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/6ewh6g8rqt2ev3a/model_final.pth?dl=1',
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/6ewh6g8rqt2ev3a/model_final.pth?dl=1",
     },
     "TableBank": {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/8v4uqmz1at9v72a/model_final.pth?dl=1',
-        'faster_rcnn_R_101_FPN_3x': 'https://www.dropbox.com/s/6vzfk8lk9xvyitg/model_final.pth?dl=1',
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/8v4uqmz1at9v72a/model_final.pth?dl=1",
+        "faster_rcnn_R_101_FPN_3x": "https://www.dropbox.com/s/6vzfk8lk9xvyitg/model_final.pth?dl=1",
     },
 }
 
 CONFIG_CATALOG = {
-    'HJDataset': {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/j4yseny2u0hn22r/config.yml?dl=1',
-        'mask_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/4jmr3xanmxmjcf8/config.yml?dl=1',
-        'retinanet_R_50_FPN_3x': 'https://www.dropbox.com/s/z8a8ywozuyc5c2x/config.yml?dl=1'
+    "HJDataset": {
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/j4yseny2u0hn22r/config.yml?dl=1",
+        "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/4jmr3xanmxmjcf8/config.yml?dl=1",
+        "retinanet_R_50_FPN_3x": "https://www.dropbox.com/s/z8a8ywozuyc5c2x/config.yml?dl=1",
     },
     "PubLayNet": {
         "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/f3b12qc4hc0yh4m/config.yml?dl=1",
         "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/u9wbsfwz4y0ziki/config.yml?dl=1",
-        "mask_rcnn_X_101_32x8d_FPN_3x": "https://www.dropbox.com/s/nau5ut6zgthunil/config.yaml?dl=1"
+        "mask_rcnn_X_101_32x8d_FPN_3x": "https://www.dropbox.com/s/nau5ut6zgthunil/config.yaml?dl=1",
     },
     "PrimaLayout": {
         "mask_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/yc92x97k50abynt/config.yaml?dl=1"
     },
     "NewspaperNavigator": {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/wnido8pk4oubyzr/config.yml?dl=1',
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/wnido8pk4oubyzr/config.yml?dl=1",
     },
     "TableBank": {
-        'faster_rcnn_R_50_FPN_3x': 'https://www.dropbox.com/s/7cqle02do7ah7k4/config.yaml?dl=1',
-        'faster_rcnn_R_101_FPN_3x': 'https://www.dropbox.com/s/h63n6nv51kfl923/config.yaml?dl=1',
+        "faster_rcnn_R_50_FPN_3x": "https://www.dropbox.com/s/7cqle02do7ah7k4/config.yaml?dl=1",
+        "faster_rcnn_R_101_FPN_3x": "https://www.dropbox.com/s/h63n6nv51kfl923/config.yaml?dl=1",
     },
+}
+
+LABEL_MAP_CATALOG = {
+    "HJDataset": {
+        1: "Page Frame",
+        2: "Row",
+        3: "Title Region",
+        4: "Text Region",
+        5: "Title",
+        6: "Subtitle",
+        7: "Other",
+    },
+    "PubLayNet": {0: "Text", 1: "Title", 2: "List", 3: "Table", 4: "Figure"},
+    "PrimaLayout": {
+        1: "TextRegion",
+        2: "ImageRegion",
+        3: "TableRegion",
+        4: "MathsRegion",
+        5: "SeparatorRegion",
+        6: "OtherRegion",
+    },
+    "NewspaperNavigator": {
+        0: "Photograph",
+        1: "Illustration",
+        2: "Map",
+        3: "Comics/Cartoon",
+        4: "Editorial Cartoon",
+        5: "Headline",
+        6: "Advertisement",
+    },
+    "TableBank": {0: "Table"},
 }
 
 
@@ -72,13 +104,13 @@ class LayoutParserHandler(PathHandler):
         return [self.PREFIX]
 
     def _get_local_path(self, path, **kwargs):
-        model_name = path[len(self.PREFIX):]
-        dataset_name, *model_name, data_type = model_name.split('/')
+        model_name = path[len(self.PREFIX) :]
+        dataset_name, *model_name, data_type = model_name.split("/")
 
-        if data_type == 'weight':
-            model_url = MODEL_CATALOG[dataset_name]['/'.join(model_name)]
-        elif data_type == 'config':
-            model_url = CONFIG_CATALOG[dataset_name]['/'.join(model_name)]
+        if data_type == "weight":
+            model_url = MODEL_CATALOG[dataset_name]["/".join(model_name)]
+        elif data_type == "config":
+            model_url = CONFIG_CATALOG[dataset_name]["/".join(model_name)]
         else:
             raise ValueError(f"Unknown data_type {data_type}")
         return PathManager.get_local_path(model_url, **kwargs)

--- a/src/layoutparser/models/layoutmodel.py
+++ b/src/layoutparser/models/layoutmodel.py
@@ -6,7 +6,7 @@ from PIL import Image
 import numpy as np
 import torch
 
-from .catalog import PathManager
+from .catalog import PathManager, LABEL_MAP_CATALOG
 from ..elements import *
 
 __all__ = ["Detectron2LayoutModel"]
@@ -65,7 +65,8 @@ class Detectron2LayoutModel(BaseLayoutModel):
             Defaults to `None`.
         label_map (:obj:`dict`, optional):
             The map from the model prediction (ids) to real
-            word labels (strings).
+            word labels (strings). If the config is from one of the supported
+            datasets, Layout Parser will automatically initialize the label_map.
             Defaults to `None`.
         extra_config (:obj:`list`, optional):
             Extra configuration passed to the Detectron2 model
@@ -91,6 +92,10 @@ class Detectron2LayoutModel(BaseLayoutModel):
     ]
 
     def __init__(self, config_path, model_path=None, label_map=None, extra_config=[]):
+
+        if config_path.startswith("lp://") and label_map is None:
+            dataset_name = config_path.lstrip("lp://").split("/")[0]
+            label_map = LABEL_MAP_CATALOG[dataset_name]
 
         cfg = self._config.get_cfg()
         config_path = PathManager.get_local_path(config_path)

--- a/src/layoutparser/models/layoutmodel.py
+++ b/src/layoutparser/models/layoutmodel.py
@@ -68,6 +68,9 @@ class Detectron2LayoutModel(BaseLayoutModel):
             word labels (strings). If the config is from one of the supported
             datasets, Layout Parser will automatically initialize the label_map.
             Defaults to `None`.
+        enforce_cpu(:obj:`bool`, optional):
+            When set to `True`, it will enforce using cpu even if it is on a CUDA
+            available device.
         extra_config (:obj:`list`, optional):
             Extra configuration passed to the Detectron2 model
             configuration. The argument will be used in the `merge_from_list
@@ -91,11 +94,21 @@ class Detectron2LayoutModel(BaseLayoutModel):
         {"import_name": "_config", "module_path": "detectron2.config"},
     ]
 
-    def __init__(self, config_path, model_path=None, label_map=None, extra_config=[]):
+    def __init__(
+        self,
+        config_path,
+        model_path=None,
+        label_map=None,
+        extra_config=[],
+        enforce_cpu=False,
+    ):
 
         if config_path.startswith("lp://") and label_map is None:
             dataset_name = config_path.lstrip("lp://").split("/")[0]
             label_map = LABEL_MAP_CATALOG[dataset_name]
+
+        if enforce_cpu:
+            extra_config.extend(["MODEL.DEVICE", "cpu"])
 
         cfg = self._config.get_cfg()
         config_path = PathManager.get_local_path(config_path)

--- a/src/layoutparser/visualization.py
+++ b/src/layoutparser/visualization.py
@@ -131,6 +131,7 @@ def draw_box(
     box_width=None,
     color_map=None,
     show_element_id=False,
+    show_element_type=False,
     id_font_size=None,
     id_font_path=None,
     id_text_color=None,
@@ -158,6 +159,10 @@ def draw_box(
             Whether to display `block.id` on the top-left corner of
             the block.
             Defaults to False.
+        show_element_id (bool, optional):
+            Whether to display `block.type` on the top-left corner of
+            the block.
+            Defaults to False.
         id_font_size (int, optional):
             Set to change the font size used for drawing `block.id`.
             Defaults to None, when the size is set to
@@ -183,7 +188,7 @@ def draw_box(
     if box_width is None:
         box_width = _calculate_default_box_width(canvas)
 
-    if show_element_id:
+    if show_element_id or show_element_type:
         font_obj = _create_font_object(id_font_size, id_font_path)
 
     if color_map is None:
@@ -208,11 +213,16 @@ def draw_box(
             p = ele.points.ravel().tolist()
             draw.line(p + p[:2], width=box_width, fill=outline_color)
 
-        if show_element_id:
-            ele_id = ele.id or idx
+        if show_element_id or show_element_type:
+            text = ""
+            if show_element_id:
+                ele_id = ele.id or idx
+                text += str(ele_id)
+            if show_element_type:
+                text = str(ele.type) if not text else text + ": " + str(ele.type)
 
             start_x, start_y = ele.coordinates[:2]
-            text_w, text_h = font_obj.getsize(f"{ele_id}")
+            text_w, text_h = font_obj.getsize(text)
 
             # Add a small background for the text
             draw.rectangle(
@@ -223,7 +233,7 @@ def draw_box(
             # Draw the ids
             draw.text(
                 (start_x, start_y),
-                f"{ele_id}",
+                text,
                 fill=id_text_color or DEFAULT_TEXT_COLOR,
                 font=font_obj,
             )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -28,3 +28,8 @@ def test_Detectron2Model(is_large_scale=False):
         model = Detectron2LayoutModel("tests/fixtures/model/config.yml")
         image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
         layout = model.detect(image)
+        
+    # Test in enforce CPU mode
+    model = Detectron2LayoutModel("tests/fixtures/model/config.yml", enforce_cpu=True)
+    image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
+    layout = model.detect(image)


### PR DESCRIPTION
1. When loading Layout Parser official models, `Detectron2LayoutModel` can automatically detect the label_map, . For example, 

    ```python
    model = lp.Detectron2LayoutModel("lp://HJDataset/faster_rcnn_R_50_FPN_3x/config")
    model.label_map
    # {1: 'Page Frame', ... }
    ```

2. `Detectron2LayoutModel` now supports the `enforce_cpu` flag that enforces using cpu even when CUDA devices are available. Inspired by #16 .
3. For `visualization.daw_box`, it now supports a `show_element_type` flag that shows the bbox category name on the top left corner of the layout objects.