### PR TITLE
[feat] Dynamic import based on the available dependencies 

### DIFF
--- a/src/layoutparser/__init__.py
+++ b/src/layoutparser/__init__.py
@@ -28,6 +28,15 @@ _import_structure = {
         "load_csv", 
         "load_dataframe"
     ],
+    "file_utils":[
+        "is_torch_available",
+        "is_torch_cuda_available",
+        "is_detectron2_available",
+        "is_paddlepaddle_available",
+        "is_pytesseract_available",
+        "is_gcv_available",
+        "requires_backends"
+    ]
 }
 
 if is_detectron2_available():

--- a/src/layoutparser/__init__.py
+++ b/src/layoutparser/__init__.py
@@ -5,7 +5,7 @@ import sys
 from .file_utils import (
     _LazyModule,
     is_detectron2_available,
-    is_paddlepaddle_available,
+    is_paddle_available,
     is_pytesseract_available,
     is_gcv_available,
 )
@@ -32,7 +32,7 @@ _import_structure = {
         "is_torch_available",
         "is_torch_cuda_available",
         "is_detectron2_available",
-        "is_paddlepaddle_available",
+        "is_paddle_available",
         "is_pytesseract_available",
         "is_gcv_available",
         "requires_backends"
@@ -42,7 +42,7 @@ _import_structure = {
 if is_detectron2_available():
     _import_structure["models.detectron2"] = ["Detectron2LayoutModel"]
 
-if is_paddlepaddle_available():
+if is_paddle_available():
     _import_structure["models.paddledetection"] = ["PaddleDetectionLayoutModel"]
 
 if is_pytesseract_available():

--- a/src/layoutparser/__init__.py
+++ b/src/layoutparser/__init__.py
@@ -1,27 +1,54 @@
 __version__ = "0.2.0"
 
-from .elements import (
-    Interval, Rectangle, Quadrilateral, 
-    TextBlock, Layout
+import sys
+
+from .file_utils import (
+    _LazyModule,
+    is_detectron2_available,
+    is_paddlepaddle_available,
+    is_pytesseract_available,
+    is_gcv_available,
 )
 
-from .visualization import (
-    draw_box, draw_text
-)
+_import_structure = {
+    "elements": [
+        "Interval", 
+        "Rectangle", 
+        "Quadrilateral", 
+        "TextBlock", 
+        "Layout"
+    ],
+    "visualization": [
+        "draw_box", 
+        "draw_text"
+    ],
+    "io": [
+        "load_json", 
+        "load_dict", 
+        "load_csv", 
+        "load_dataframe"
+    ],
+}
 
-from .ocr import (
-    GCVFeatureType, GCVAgent, 
-    TesseractFeatureType, TesseractAgent
-)
+if is_detectron2_available():
+    _import_structure["models.detectron2"] = ["Detectron2LayoutModel"]
 
-from .models import (
-    Detectron2LayoutModel,
-    PaddleDetectionLayoutModel
-)
+if is_paddlepaddle_available():
+    _import_structure["models.paddledetection"] = ["PaddleDetectionLayoutModel"]
 
-from .io import (
-    load_json,
-    load_dict,
-    load_csv,
-    load_dataframe
+if is_pytesseract_available():
+    _import_structure["ocr.tesseract_agent"] = [
+        "TesseractAgent",
+        "TesseractFeatureType",
+    ]
+
+if is_gcv_available():
+    _import_structure["ocr.gcv_agent"] = ["GCVAgent", "GCVFeatureType"]
+
+sys.modules[__name__] = _LazyModule(
+    __name__,
+    globals()["__file__"],
+    _import_structure,
+    module_spec=__spec__,
+    extra_objects={"__version__": __version__},
 )

--- a/src/layoutparser/file_utils.py
+++ b/src/layoutparser/file_utils.py
@@ -30,16 +30,19 @@ except importlib_metadata.PackageNotFoundError:
 _detectron2_available = importlib.util.find_spec("detectron2") is not None
 try:
     _detectron2_version = importlib_metadata.version("detectron2")
-    logger.debug(f"Successfully imported detectron2 version {_detectron2_version}")
+    logger.debug(f"Detectron2 version {_detectron2_version} available")
 except importlib_metadata.PackageNotFoundError:
     _detectron2_available = False
 
-_paddlepaddle_available = importlib.util.find_spec("paddlepaddle") is not None
+_paddle_available = importlib.util.find_spec("paddle") is not None
 try:
-    _paddlepaddle_version = importlib_metadata.version("paddlepaddle")
-    logger.debug(f"PaddlePaddle version {_paddlepaddle_version} available.")
+    # The name of the paddlepaddle library:
+    # Install name: pip install paddlepaddle
+    # Import name: import paddle
+    _paddle_version = importlib_metadata.version("paddlepaddle") 
+    logger.debug(f"Paddle version {_paddle_version} available.")
 except importlib_metadata.PackageNotFoundError:
-    _paddlepaddle_available = False
+    _paddle_available = False
 
 ###########################################
 ############## OCR Tool Deps ##############
@@ -75,8 +78,8 @@ def is_torch_cuda_available():
         return False
 
 
-def is_paddlepaddle_available():
-    return _paddlepaddle_available
+def is_paddle_available():
+    return _paddle_available
 
 
 def is_detectron2_available():
@@ -103,7 +106,7 @@ that match your environment. Typically the following would work for MacOS or Lin
     pip install 'git+https://github.com/facebookresearch/detectron2.git@v0.4#egg=detectron2' 
 """
 
-PADDLEPADDLE_IMPORT_ERROR = """
+PADDLE_IMPORT_ERROR = """
 {0} requires the PaddlePaddle library but it was not found in your environment. Checkout the instructions on the
 installation page: https://github.com/PaddlePaddle/Paddle and follow the ones that match your environment.
 """
@@ -122,7 +125,7 @@ BACKENDS_MAPPING = dict(
     [
         ("torch", (is_torch_available, PYTORCH_IMPORT_ERROR)),
         ("detectron2", (is_detectron2_available, DETECTRON2_IMPORT_ERROR)),
-        ("paddlepaddle", (is_paddlepaddle_available, PADDLEPADDLE_IMPORT_ERROR)),
+        ("paddle", (is_paddle_available, PADDLE_IMPORT_ERROR)),
         ("pytesseract", (is_pytesseract_available, PYTESSERACT_IMPORT_ERROR)),
         ("google-cloud-vision", (is_gcv_available, GCV_IMPORT_ERROR)),
     ]

--- a/src/layoutparser/file_utils.py
+++ b/src/layoutparser/file_utils.py
@@ -124,7 +124,7 @@ BACKENDS_MAPPING = dict(
         ("detectron2", (is_detectron2_available, DETECTRON2_IMPORT_ERROR)),
         ("paddlepaddle", (is_paddlepaddle_available, PADDLEPADDLE_IMPORT_ERROR)),
         ("pytesseract", (is_pytesseract_available, PYTESSERACT_IMPORT_ERROR)),
-        ("gcv", (is_gcv_available, GCV_IMPORT_ERROR)),
+        ("google-cloud-vision", (is_gcv_available, GCV_IMPORT_ERROR)),
     ]
 )
 

--- a/src/layoutparser/file_utils.py
+++ b/src/layoutparser/file_utils.py
@@ -1,0 +1,198 @@
+# Some code are adapted from
+# https://github.com/huggingface/transformers/blob/master/src/transformers/file_utils.py
+
+from typing import Any, BinaryIO, Dict, List, Optional, Tuple, Union
+import sys
+import os
+import logging
+import importlib.util
+from types import ModuleType
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+###########################################
+############ Layout Model Deps ############
+###########################################
+
+_torch_available = importlib.util.find_spec("torch") is not None
+try:
+    _torch_version = importlib_metadata.version("torch")
+    logger.debug(f"PyTorch version {_torch_version} available.")
+except importlib_metadata.PackageNotFoundError:
+    _torch_available = False
+
+_detectron2_available = importlib.util.find_spec("detectron2") is not None
+try:
+    _detectron2_version = importlib_metadata.version("detectron2")
+    logger.debug(f"Successfully imported detectron2 version {_detectron2_version}")
+except importlib_metadata.PackageNotFoundError:
+    _detectron2_available = False
+
+_paddlepaddle_available = importlib.util.find_spec("paddlepaddle") is not None
+try:
+    _paddlepaddle_version = importlib_metadata.version("paddlepaddle")
+    logger.debug(f"PaddlePaddle version {_paddlepaddle_version} available.")
+except importlib_metadata.PackageNotFoundError:
+    _paddlepaddle_available = False
+
+###########################################
+############## OCR Tool Deps ##############
+###########################################
+
+_pytesseract_available = importlib.util.find_spec("pytesseract") is not None
+try:
+    _pytesseract_version = importlib_metadata.version("pytesseract")
+    logger.debug(f"Pytesseract version {_pytesseract_version} available.")
+except importlib_metadata.PackageNotFoundError:
+    _pytesseract_available = False
+
+_gcv_available = importlib.util.find_spec("google.cloud.vision") is not None
+try:
+    _gcv_version = importlib_metadata.version(
+        "google-cloud-vision"
+    )  # This is slightly different
+    logger.debug(f"Google Cloud Vision Utils version {_gcv_version} available.")
+except importlib_metadata.PackageNotFoundError:
+    _gcv_available = False
+
+
+def is_torch_available():
+    return _torch_available
+
+
+def is_torch_cuda_available():
+    if is_torch_available():
+        import torch
+
+        return torch.cuda.is_available()
+    else:
+        return False
+
+
+def is_paddlepaddle_available():
+    return _paddlepaddle_available
+
+
+def is_detectron2_available():
+    return _detectron2_available
+
+
+def is_pytesseract_available():
+    return _pytesseract_available
+
+
+def is_gcv_available():
+    return _gcv_available
+
+
+PYTORCH_IMPORT_ERROR = """
+{0} requires the PyTorch library but it was not found in your environment. Checkout the instructions on the
+installation page: https://pytorch.org/get-started/locally/ and follow the ones that match your environment.
+"""
+
+DETECTRON2_IMPORT_ERROR = """
+{0} requires the detectron2 library but it was not found in your environment. Checkout the instructions on the
+installation page: https://github.com/facebookresearch/detectron2/blob/master/INSTALL.md and follow the ones
+that match your environment. Typically the following would work for MacOS or Linux CPU machines:
+    pip install 'git+https://github.com/facebookresearch/detectron2.git@v0.4#egg=detectron2' 
+"""
+
+PADDLEPADDLE_IMPORT_ERROR = """
+{0} requires the PaddlePaddle library but it was not found in your environment. Checkout the instructions on the
+installation page: https://github.com/PaddlePaddle/Paddle and follow the ones that match your environment.
+"""
+
+PYTESSERACT_IMPORT_ERROR = """
+{0} requires the PyTesseract library but it was not found in your environment. You can install it with pip:
+`pip install pytesseract`
+"""
+
+GCV_IMPORT_ERROR = """
+{0} requires the Google Cloud Vision Python utils but it was not found in your environment. You can install it with pip:
+`pip install google-cloud-vision==1`
+"""
+
+BACKENDS_MAPPING = dict(
+    [
+        ("torch", (is_torch_available, PYTORCH_IMPORT_ERROR)),
+        ("detectron2", (is_detectron2_available, DETECTRON2_IMPORT_ERROR)),
+        ("paddlepaddle", (is_paddlepaddle_available, PADDLEPADDLE_IMPORT_ERROR)),
+        ("pytesseract", (is_pytesseract_available, PYTESSERACT_IMPORT_ERROR)),
+        ("gcv", (is_gcv_available, GCV_IMPORT_ERROR)),
+    ]
+)
+
+
+def requires_backends(obj, backends):
+    if not isinstance(backends, (list, tuple)):
+        backends = [backends]
+
+    name = obj.__name__ if hasattr(obj, "__name__") else obj.__class__.__name__
+    if not all(BACKENDS_MAPPING[backend][0]() for backend in backends):
+        raise ImportError(
+            "".join([BACKENDS_MAPPING[backend][1].format(name) for backend in backends])
+        )
+
+
+class _LazyModule(ModuleType):
+    """
+    Module class that surfaces all objects but only performs associated imports when the objects are requested.
+    """
+
+    # Adapted from HuggingFace
+    # https://github.com/huggingface/transformers/blob/c37573806ab3526dd805c49cbe2489ad4d68a9d7/src/transformers/file_utils.py#L1990
+
+    def __init__(
+        self, name, module_file, import_structure, module_spec=None, extra_objects=None
+    ):
+        super().__init__(name)
+        self._modules = set(import_structure.keys())
+        self._class_to_module = {}
+        for key, values in import_structure.items():
+            for value in values:
+                self._class_to_module[value] = key
+        # Needed for autocompletion in an IDE
+        self.__all__ = list(import_structure.keys()) + sum(
+            import_structure.values(), []
+        )
+        self.__file__ = module_file
+        self.__spec__ = module_spec
+        self.__path__ = [os.path.dirname(module_file)]
+        self._objects = {} if extra_objects is None else extra_objects
+        self._name = name
+        self._import_structure = import_structure
+
+        # Following [PEP 366](https://www.python.org/dev/peps/pep-0366/)
+        # The __package__ variable should be set 
+        # https://docs.python.org/3/reference/import.html#__package__
+        self.__package__ = self.__name__
+
+    # Needed for autocompletion in an IDE
+    def __dir__(self):
+        return super().__dir__() + self.__all__
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._objects:
+            return self._objects[name]
+        if name in self._modules:
+            value = self._get_module(name)
+        elif name in self._class_to_module.keys():
+            module = self._get_module(self._class_to_module[name])
+            value = getattr(module, name)
+        else:
+            raise AttributeError(f"module {self.__name__} has no attribute {name}")
+
+        setattr(self, name, value)
+        return value
+
+    def _get_module(self, module_name: str):
+        return importlib.import_module("." + module_name, self.__name__)
+
+    def __reduce__(self):
+        return (self.__class__, (self._name, self.__file__, self._import_structure))

--- a/src/layoutparser/models/base_layoutmodel.py
+++ b/src/layoutparser/models/base_layoutmodel.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
-import os
-import importlib
+
+from ..file_utils import requires_backends
 
 
 class BaseLayoutModel(ABC):
@@ -23,28 +23,7 @@ class BaseLayoutModel(ABC):
         """DEPENDENCIES lists all necessary dependencies for the class."""
         pass
 
-    @property
-    @abstractmethod
-    def MODULES(self):
-        """MODULES instructs how to import these necessary libraries."""
-        pass
-
-    @classmethod
-    def _import_module(cls):
-        for m in cls.MODULES:
-            if importlib.util.find_spec(m["module_path"]):
-                setattr(
-                    cls, m["import_name"], importlib.import_module(m["module_path"])
-                )
-            else:
-                raise ModuleNotFoundError(
-                    f"\n "
-                    f"\nPlease install the following libraries to support the class {cls.__name__}:"
-                    f"\n    pip install {' '.join(cls.DEPENDENCIES)}"
-                    f"\n "
-                )
-
     def __new__(cls, *args, **kwargs):
 
-        cls._import_module()
+        requires_backends(cls, cls.DEPENDENCIES)
         return super().__new__(cls)

--- a/src/layoutparser/models/paddledetection/layoutmodel.py
+++ b/src/layoutparser/models/paddledetection/layoutmodel.py
@@ -10,6 +10,11 @@ from .catalog import PathManager, LABEL_MAP_CATALOG
 from ..base_layoutmodel import BaseLayoutModel
 from ...elements import Rectangle, TextBlock, Layout
 
+from ...file_utils import is_paddle_available
+
+if is_paddle_available():
+    import paddle.inference
+
 
 __all__ = ["PaddleDetectionLayoutModel"]
 
@@ -81,13 +86,7 @@ class PaddleDetectionLayoutModel(BaseLayoutModel):
 
     """
 
-    DEPENDENCIES = ["paddlepaddle"]
-    MODULES = [
-        {
-            "import_name": "_inference",
-            "module_path": "paddle.inference",
-        },
-    ]
+    DEPENDENCIES = ["paddle"]
     DETECTOR_NAME = "paddledetection"
 
     def __init__(
@@ -178,7 +177,7 @@ class PaddleDetectionLayoutModel(BaseLayoutModel):
             ValueError: predict by TensorRT need enforce_cpu == False.
         """
 
-        config = self._inference.Config(
+        config = paddle.inference.Config(
             os.path.join(
                 model_dir, "inference.pdmodel"
             ),  # TODO: Move them to some constants
@@ -211,7 +210,7 @@ class PaddleDetectionLayoutModel(BaseLayoutModel):
         config.enable_memory_optim()
         # disable feed, fetch OP, needed by zero_copy_run
         config.switch_use_feed_fetch_ops(False)
-        predictor = self._inference.create_predictor(config)
+        predictor = paddle.inference.create_predictor(config)
         return predictor
 
     def preprocess(self, image):

--- a/src/layoutparser/ocr/base.py
+++ b/src/layoutparser/ocr/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from enum import IntEnum
-import importlib
 
+from ..file_utils import requires_backends
 
 class BaseOCRElementType(IntEnum):
     @property
@@ -17,49 +17,9 @@ class BaseOCRAgent(ABC):
         """DEPENDENCIES lists all necessary dependencies for the class."""
         pass
 
-    @property
-    @abstractmethod
-    def MODULES(self):
-        """MODULES instructs how to import these necessary libraries.
-
-        Note:
-            Sometimes a python module have different installation name and module name (e.g.,
-            `pip install tensorflow-gpu` when installing and `import tensorflow` when using
-            ). And sometimes we only need to import a submodule but not whole module. MODULES
-            is designed for this purpose.
-
-        Returns:
-            :obj: list(dict): A list of dict indicate how the model is imported.
-
-                Example::
-
-                    [{
-                        "import_name": "_vision",
-                        "module_path": "google.cloud.vision"
-                    }]
-
-                    is equivalent to self._vision = importlib.import_module("google.cloud.vision")
-        """
-        pass
-
-    @classmethod
-    def _import_module(cls):
-        for m in cls.MODULES:
-            if importlib.util.find_spec(m["module_path"]):
-                setattr(
-                    cls, m["import_name"], importlib.import_module(m["module_path"])
-                )
-            else:
-                raise ModuleNotFoundError(
-                    f"\n "
-                    f"\nPlease install the following libraries to support the class {cls.__name__}:"
-                    f"\n    pip install {' '.join(cls.DEPENDENCIES)}"
-                    f"\n "
-                )
-
     def __new__(cls, *args, **kwargs):
 
-        cls._import_module()
+        requires_backends(cls, cls.DEPENDENCIES)
         return super().__new__(cls)
 
     @abstractmethod

--- a/src/layoutparser/ocr/gcv_agent.py
+++ b/src/layoutparser/ocr/gcv_agent.py
@@ -6,6 +6,9 @@ import warnings
 import numpy as np
 from cv2 import imencode
 
+import google.protobuf.json_format as _json_format
+import google.cloud.vision as _vision
+
 from .base import BaseOCRAgent, BaseOCRElementType
 from ..elements import Layout, TextBlock, Quadrilateral, TextBlock
 
@@ -72,11 +75,7 @@ class GCVAgent(BaseOCRAgent):
     """
 
     DEPENDENCIES = ["google-cloud-vision"]
-    MODULES = [
-        {"import_name": "_vision", "module_path": "google.cloud.vision"},
-        {"import_name": "_json_format", "module_path": "google.protobuf.json_format"},
-    ]
-
+    
     def __init__(self, languages=None, ocr_image_decode_type=".png"):
         """Create a Google Cloud Vision OCR Agent.
 
@@ -95,12 +94,12 @@ class GCVAgent(BaseOCRAgent):
                     * But `".jpg"` could also be a good choice if the input image is very large.
         """
         try:
-            self._client = self._vision.ImageAnnotatorClient()
+            self._client = _vision.ImageAnnotatorClient()
         except:
             warnings.warn(
                 "The GCV credential has not been set. You could not run the detect command."
             )
-        self._context = self._vision.types.ImageContext(language_hints=languages)
+        self._context = _vision.types.ImageContext(language_hints=languages)
         self.ocr_image_decode_type = ocr_image_decode_type
 
     @classmethod
@@ -114,7 +113,7 @@ class GCVAgent(BaseOCRAgent):
         return cls(**kwargs)
 
     def _detect(self, img_content):
-        img_content = self._vision.types.Image(content=img_content)
+        img_content = _vision.types.Image(content=img_content)
         response = self._client.document_text_detection(
             image=img_content, image_context=self._context
         )
@@ -260,12 +259,12 @@ class GCVAgent(BaseOCRAgent):
     def load_response(self, filename):
         with open(filename, "r") as f:
             data = f.read()
-        return self._json_format.Parse(
-            data, self._vision.types.AnnotateImageResponse(), ignore_unknown_fields=True
+        return _json_format.Parse(
+            data, _vision.types.AnnotateImageResponse(), ignore_unknown_fields=True
         )
 
     def save_response(self, res, file_name):
-        res = self._json_format.MessageToJson(res)
+        res = _json_format.MessageToJson(res)
 
         with open(file_name, "w") as f:
             json_file = json.loads(res)

--- a/src/layoutparser/ocr/gcv_agent.py
+++ b/src/layoutparser/ocr/gcv_agent.py
@@ -6,11 +6,14 @@ import warnings
 import numpy as np
 from cv2 import imencode
 
-import google.protobuf.json_format as _json_format
-import google.cloud.vision as _vision
-
 from .base import BaseOCRAgent, BaseOCRElementType
 from ..elements import Layout, TextBlock, Quadrilateral, TextBlock
+from ..file_utils import is_gcv_available
+
+if is_gcv_available():
+    import google.protobuf.json_format as _json_format
+    import google.cloud.vision as _vision
+
 
 
 def _cvt_GCV_vertices_to_points(vertices):

--- a/src/layoutparser/ocr/tesseract_agent.py
+++ b/src/layoutparser/ocr/tesseract_agent.py
@@ -3,10 +3,14 @@ import csv
 import pickle
 
 import pandas as pd
-import pytesseract
 
 from .base import BaseOCRAgent, BaseOCRElementType
 from ..io import load_dataframe
+from ..file_utils import is_pytesseract_available
+
+if is_pytesseract_available():
+    import pytesseract
+
 
 class TesseractFeatureType(BaseOCRElementType):
     """
@@ -41,6 +45,7 @@ class TesseractAgent(BaseOCRAgent):
     A wrapper for `Tesseract <https://github.com/tesseract-ocr/tesseract>`_ Text
     Detection APIs based on `PyTesseract <https://github.com/tesseract-ocr/tesseract>`_.
     """
+
     DEPENDENCIES = ["pytesseract"]
 
     def __init__(self, languages="eng", **kwargs):
@@ -70,9 +75,7 @@ class TesseractAgent(BaseOCRAgent):
         res["text"] = pytesseract.image_to_string(
             img_content, lang=self.lang, **self.configs
         )
-        _data = pytesseract.image_to_data(
-            img_content, lang=self.lang, **self.configs
-        )
+        _data = pytesseract.image_to_data(img_content, lang=self.lang, **self.configs)
         res["data"] = pd.read_csv(
             io.StringIO(_data), quoting=csv.QUOTE_NONE, encoding="utf-8", sep="\t"
         )
@@ -149,7 +152,11 @@ class TesseractAgent(BaseOCRAgent):
                     "index": "id",
                 }
             )
-            .assign(x_2=lambda x: x.x_1 + x.w, y_2=lambda x: x.y_1 + x.h, block_type="rectangle")
+            .assign(
+                x_2=lambda x: x.x_1 + x.w,
+                y_2=lambda x: x.y_1 + x.h,
+                block_type="rectangle",
+            )
             .drop(columns=["w", "h"])
         )
 

--- a/src/layoutparser/ocr/tesseract_agent.py
+++ b/src/layoutparser/ocr/tesseract_agent.py
@@ -3,6 +3,7 @@ import csv
 import pickle
 
 import pandas as pd
+import pytesseract
 
 from .base import BaseOCRAgent, BaseOCRElementType
 from ..io import load_dataframe
@@ -40,9 +41,7 @@ class TesseractAgent(BaseOCRAgent):
     A wrapper for `Tesseract <https://github.com/tesseract-ocr/tesseract>`_ Text
     Detection APIs based on `PyTesseract <https://github.com/tesseract-ocr/tesseract>`_.
     """
-
     DEPENDENCIES = ["pytesseract"]
-    MODULES = [{"import_name": "_pytesseract", "module_path": "pytesseract"}]
 
     def __init__(self, languages="eng", **kwargs):
         """Create a Tesseract OCR Agent.
@@ -63,15 +62,15 @@ class TesseractAgent(BaseOCRAgent):
     @classmethod
     def with_tesseract_executable(cls, tesseract_cmd_path, **kwargs):
 
-        cls._pytesseract.pytesseract.tesseract_cmd = tesseract_cmd_path
+        pytesseract.pytesseract.tesseract_cmd = tesseract_cmd_path
         return cls(**kwargs)
 
     def _detect(self, img_content):
         res = {}
-        res["text"] = self._pytesseract.image_to_string(
+        res["text"] = pytesseract.image_to_string(
             img_content, lang=self.lang, **self.configs
         )
-        _data = self._pytesseract.image_to_data(
+        _data = pytesseract.image_to_data(
             img_content, lang=self.lang, **self.configs
         )
         res["data"] = pd.read_csv(

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,4 +1,4 @@
-from layoutparser.ocr import (
+from layoutparser import (
     GCVAgent,
     GCVFeatureType,
     TesseractAgent,


### PR DESCRIPTION
After this update, layout-parser would support the [`_LazyModule`(originally from the transformers repo)](https://github.com/huggingface/transformers/blob/c37573806ab3526dd805c49cbe2489ad4d68a9d7/src/transformers/file_utils.py#L1990) that enables more flexible imports and dependency management. 

For all OCR and LayoutModels, it may require additional dependencies installed beyond the base layout-parser implementation. Previously we resort to the method `_import_module` that binds the loading of the external dependencies to the specific classes. As a result, the import of the required dependencies should be handled within the classes, adding complexity to the model implementation. 

In the new updates, the additional dependencies is handled at the library level: if the dependencies is not available, the actual python file for the corresponding class won't be imported and loaded as a part of the library. For example, if `Detectron2` is not installed, after running `import layoutparser as lp`, the `lp` object even won't have the attribute `Detectron2LayoutModel`. This decouples the requirements with the corresponding class, and makes it easier to implement new models. 

