### PR TITLE
[feat] AutoLayoutModel and flexible model configs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,17 +31,29 @@ setup(name         = "layoutparser",
           'google-cloud-vision==1',
           'pytesseract'
         ], 
+        "gcv": [
+          'google-cloud-vision==1',
+        ],
+        "tesseract": [
+          'pytesseract'
+        ],
+        "layoutmodels": [
+          "torch",
+          "torchvision",
+          "effdet"
+        ],
         "effdet": [
           "torch",
           "torchvision",
           "effdet"
         ],
         "detectron2": [
-          "detectron2@git+https://github.com/facebookresearch/detectron2.git@v0.4#egg=detectron2"
+          "detectron2@git+https://github.com/facebookresearch/detectron2.git@v0.5#egg=detectron2"
+          # Supporting detectron0.5 for compatibility with newer torch versions 
         ],
         "paddledetection": [
           "paddlepaddle==2.1.0"
-        ]
+        ],
       },
       include_package_data=True
       )

--- a/src/layoutparser/__init__.py
+++ b/src/layoutparser/__init__.py
@@ -40,6 +40,8 @@ _import_structure = {
     ]
 }
 
+_import_structure["models"] = ["AutoLayoutModel"]
+
 if is_detectron2_available():
     _import_structure["models.detectron2"] = ["Detectron2LayoutModel"]
 

--- a/src/layoutparser/models/__init__.py
+++ b/src/layoutparser/models/__init__.py
@@ -1,3 +1,30 @@
 from .detectron2.layoutmodel import Detectron2LayoutModel
 from .paddledetection.layoutmodel import PaddleDetectionLayoutModel
 from .effdet.layoutmodel import EfficientDetLayoutModel
+from .model_config import (
+    is_lp_layout_model_config_any_format,
+    add_identifier_for_config,
+    layout_model_config_parser,
+)
+
+ALL_AVAILABLE_BACKENDS = {
+    Detectron2LayoutModel.DETECTOR_NAME: Detectron2LayoutModel,
+    PaddleDetectionLayoutModel.DETECTOR_NAME: PaddleDetectionLayoutModel,
+    EfficientDetLayoutModel.DETECTOR_NAME: EfficientDetLayoutModel,
+}
+
+
+def AutoLayoutModel(
+    config_path, model_path=None, label_map=None, extra_config=None, device=None
+):
+    if not is_lp_layout_model_config_any_format(config_path):
+        raise ValueError(f"Invalid model config_path {config_path}")
+    for backend_name in ALL_AVAILABLE_BACKENDS:
+        if backend_name in config_path:
+            return ALL_AVAILABLE_BACKENDS[backend_name](
+                config_path,
+                model_path=model_path,
+                label_map=label_map,
+                extra_config=extra_config,
+                device=device,
+            )

--- a/src/layoutparser/models/__init__.py
+++ b/src/layoutparser/models/__init__.py
@@ -1,30 +1,4 @@
 from .detectron2.layoutmodel import Detectron2LayoutModel
 from .paddledetection.layoutmodel import PaddleDetectionLayoutModel
 from .effdet.layoutmodel import EfficientDetLayoutModel
-from .model_config import (
-    is_lp_layout_model_config_any_format,
-    add_identifier_for_config,
-    layout_model_config_parser,
-)
-
-ALL_AVAILABLE_BACKENDS = {
-    Detectron2LayoutModel.DETECTOR_NAME: Detectron2LayoutModel,
-    PaddleDetectionLayoutModel.DETECTOR_NAME: PaddleDetectionLayoutModel,
-    EfficientDetLayoutModel.DETECTOR_NAME: EfficientDetLayoutModel,
-}
-
-
-def AutoLayoutModel(
-    config_path, model_path=None, label_map=None, extra_config=None, device=None
-):
-    if not is_lp_layout_model_config_any_format(config_path):
-        raise ValueError(f"Invalid model config_path {config_path}")
-    for backend_name in ALL_AVAILABLE_BACKENDS:
-        if backend_name in config_path:
-            return ALL_AVAILABLE_BACKENDS[backend_name](
-                config_path,
-                model_path=model_path,
-                label_map=label_map,
-                extra_config=extra_config,
-                device=device,
-            )
+from .auto_layoutmodel import AutoLayoutModel

--- a/src/layoutparser/models/auto_layoutmodel.py
+++ b/src/layoutparser/models/auto_layoutmodel.py
@@ -1,0 +1,56 @@
+from typing import Optional, Dict, Union, List
+from .detectron2.layoutmodel import Detectron2LayoutModel
+from .paddledetection.layoutmodel import PaddleDetectionLayoutModel
+from .effdet.layoutmodel import EfficientDetLayoutModel
+from .model_config import (
+    is_lp_layout_model_config_any_format,
+)
+
+ALL_AVAILABLE_BACKENDS = {
+    Detectron2LayoutModel.DETECTOR_NAME: Detectron2LayoutModel,
+    PaddleDetectionLayoutModel.DETECTOR_NAME: PaddleDetectionLayoutModel,
+    EfficientDetLayoutModel.DETECTOR_NAME: EfficientDetLayoutModel,
+}
+
+
+def AutoLayoutModel(
+    config_path: str,
+    model_path: Optional[str] = None,
+    label_map: Optional[Dict]=None,
+    device: Optional[str]=None,
+    extra_config: Optional[Union[Dict, List]]=None,
+) -> "BaseLayoutModel":
+    """[summary]
+
+    Args:
+        config_path (:obj:`str`):
+            The path to the configuration file.
+        model_path (:obj:`str`, None):
+            The path to the saved weights of the model.
+            If set, overwrite the weights in the configuration file.
+            Defaults to `None`.
+        label_map (:obj:`dict`, optional):
+            The map from the model prediction (ids) to real
+            word labels (strings). If the config is from one of the supported
+            datasets, Layout Parser will automatically initialize the label_map.
+            Defaults to `None`.
+        device(:obj:`str`, optional):
+            Whether to use cuda or cpu devices. If not set, LayoutParser will
+            automatically determine the device to initialize the models on. 
+        extra_config (:obj:`dict`, optional):
+            Extra configuration passed used for initializing the layout model.
+
+    Returns:
+        # BaseLayoutModel: the create LayoutModel instance
+    """
+    if not is_lp_layout_model_config_any_format(config_path):
+        raise ValueError(f"Invalid model config_path {config_path}")
+    for backend_name in ALL_AVAILABLE_BACKENDS:
+        if backend_name in config_path:
+            return ALL_AVAILABLE_BACKENDS[backend_name](
+                config_path,
+                model_path=model_path,
+                label_map=label_map,
+                extra_config=extra_config,
+                device=device,
+            )

--- a/src/layoutparser/models/base_layoutmodel.py
+++ b/src/layoutparser/models/base_layoutmodel.py
@@ -1,26 +1,11 @@
-from typing import Union
+from typing import Optional, Tuple, Union, Dict
 from abc import ABC, abstractmethod
 
+from .model_config import LayoutModelConfig, add_identifier_for_config, layout_model_config_parser, is_lp_layout_model_config_any_format
 from ..file_utils import requires_backends
 
-
 class BaseLayoutModel(ABC):
-    @property
-    @abstractmethod
-    def DETECTOR_NAME(self):
-        pass
 
-    @abstractmethod
-    def detect(self, image):
-        pass
-
-    @abstractmethod
-    def image_loader(self, image: Union["np.ndarray", "Image.Image"]):
-        """It will process the input images appropriately to the target format."""
-        pass
-
-    # Add lazy loading mechanisms for layout models, refer to
-    # layoutparser.ocr.BaseOCRAgent
     # TODO: Build a metaclass for lazy module loader
     @property
     @abstractmethod
@@ -28,36 +13,61 @@ class BaseLayoutModel(ABC):
         """DEPENDENCIES lists all necessary dependencies for the class."""
         pass
 
+    @property
+    @abstractmethod
+    def DETECTOR_NAME(self):
+        pass
+
+    @property
+    @abstractmethod
+    def MODEL_CATALOG(self) -> Dict[str, Dict[str, str]]:
+        pass
+
+    @abstractmethod
+    def detect(self, image: Union["np.ndarray", "Image.Image"]):
+        pass
+
+
+    @abstractmethod
+    def image_loader(self, image: Union["np.ndarray", "Image.Image"]):
+        """It will process the input images appropriately to the target format."""
+        pass
+    
+    def _parse_config(self, config_path:str, identifier:str) -> Union[LayoutModelConfig, str]:
+        
+        if is_lp_layout_model_config_any_format(config_path):
+            config_path = add_identifier_for_config(config_path, identifier)
+            for dataset_name in self.MODEL_CATALOG:
+                if dataset_name in config_path:
+                    default_model_arch = list(self.MODEL_CATALOG[dataset_name].keys())[0]
+                    # Use the first model_name for the dataset as the default_model_arch
+                    return layout_model_config_parser(config_path, self.DETECTOR_NAME, default_model_arch)
+            raise ValueError(f"The config {config_path} is not a valid config for {self.__class__}")
+        else:
+            return config_path
+
+    def config_parser(self, config_path:str, model_path: Optional[str], allow_empty_path=False) -> Tuple[str, str]:
+
+        config_path = self._parse_config(config_path, "config")
+        
+        if isinstance(config_path, str) and model_path is None:
+            if not allow_empty_path:
+                raise ValueError(
+                    f"Invalid config and model path pairs ({(config_path, model_path)}):"
+                    f"When config_path is a regular URL, the model_path should not be empty"
+                )
+            else:
+                return config_path, model_path
+        elif isinstance(config_path, LayoutModelConfig) and model_path is None:
+            model_path = config_path.dual()
+        else:
+            model_path = self._parse_config(model_path, "weight")
+
+        config_path = config_path if isinstance(config_path, str) else config_path.full
+        model_path = model_path if isinstance(model_path, str) else model_path.full
+        return config_path, model_path
+
     def __new__(cls, *args, **kwargs):
 
         requires_backends(cls, cls.DEPENDENCIES)
         return super().__new__(cls)
-
-    def _reconstruct_path_with_detector_name(self, path: str) -> str:
-        """This function will add the detector name into the
-        lp model config path to get the "canonical" model name.
-
-        For example,
-        for a given config_path `lp://HJDataset/faster_rcnn_R_50_FPN_3x/config`,it will
-        transform it into `lp://<self.DETECTOR_NAME>/HJDataset/faster_rcnn_R_50_FPN_3x/config`.
-        However, if the config_path already contains the detector name, we won't change it.
-
-        This function is a general step to support multiple backends in the layout-parser
-        library.
-
-        Args:
-            path (str): The given input path that might or might not contain the detector name.
-
-        Returns:
-            str: a modified path that contains the detector name.
-        """
-
-        if path.startswith("lp://"):  # TODO: Move "lp://" to a constant
-            model_name = path[len("lp://") :]
-            model_name_segments = model_name.split("/")
-            if (
-                len(model_name_segments) == 3
-                and self.DETECTOR_NAME not in model_name_segments
-            ):
-                return "lp://" + self.DETECTOR_NAME + "/" + path[len("lp://") :]
-        return path

--- a/src/layoutparser/models/base_layoutmodel.py
+++ b/src/layoutparser/models/base_layoutmodel.py
@@ -15,9 +15,8 @@ class BaseLayoutModel(ABC):
         pass
 
     @abstractmethod
-    def image_loader(self, image: Union["ndarray", "Image"]):
-        """It will process the input images appropriately to the target format. 
-        """
+    def image_loader(self, image: Union["np.ndarray", "Image.Image"]):
+        """It will process the input images appropriately to the target format."""
         pass
 
     # Add lazy loading mechanisms for layout models, refer to
@@ -33,3 +32,32 @@ class BaseLayoutModel(ABC):
 
         requires_backends(cls, cls.DEPENDENCIES)
         return super().__new__(cls)
+
+    def _reconstruct_path_with_detector_name(self, path: str) -> str:
+        """This function will add the detector name into the
+        lp model config path to get the "canonical" model name.
+
+        For example,
+        for a given config_path `lp://HJDataset/faster_rcnn_R_50_FPN_3x/config`,it will
+        transform it into `lp://<self.DETECTOR_NAME>/HJDataset/faster_rcnn_R_50_FPN_3x/config`.
+        However, if the config_path already contains the detector name, we won't change it.
+
+        This function is a general step to support multiple backends in the layout-parser
+        library.
+
+        Args:
+            path (str): The given input path that might or might not contain the detector name.
+
+        Returns:
+            str: a modified path that contains the detector name.
+        """
+
+        if path.startswith("lp://"):  # TODO: Move "lp://" to a constant
+            model_name = path[len("lp://") :]
+            model_name_segments = model_name.split("/")
+            if (
+                len(model_name_segments) == 3
+                and self.DETECTOR_NAME not in model_name_segments
+            ):
+                return "lp://" + self.DETECTOR_NAME + "/" + path[len("lp://") :]
+        return path

--- a/src/layoutparser/models/base_layoutmodel.py
+++ b/src/layoutparser/models/base_layoutmodel.py
@@ -42,7 +42,8 @@ class BaseLayoutModel(ABC):
                     default_model_arch = list(self.MODEL_CATALOG[dataset_name].keys())[0]
                     # Use the first model_name for the dataset as the default_model_arch
                     return layout_model_config_parser(config_path, self.DETECTOR_NAME, default_model_arch)
-            raise ValueError(f"The config {config_path} is not a valid config for {self.__class__}")
+            raise ValueError(f"The config {config_path} is not a valid config for {self.__class__}, "
+                             f"possibly because there aren't models trained for the specified dataset.")
         else:
             return config_path
 

--- a/src/layoutparser/models/detectron2/layoutmodel.py
+++ b/src/layoutparser/models/detectron2/layoutmodel.py
@@ -87,33 +87,6 @@ class Detectron2LayoutModel(BaseLayoutModel):
         self.label_map = label_map
         self._create_model()
 
-    def _reconstruct_path_with_detector_name(self, path: str) -> str:
-        """This function will add the detector name (detectron2) into the
-        lp model config path to get the "canonical" model name.
-
-        For example, for a given config_path `lp://HJDataset/faster_rcnn_R_50_FPN_3x/config`,
-        it will transform it into `lp://detectron2/HJDataset/faster_rcnn_R_50_FPN_3x/config`.
-        However, if the config_path already contains the detector name, we won't change it.
-
-        This function is a general step to support multiple backends in the layout-parser
-        library.
-
-        Args:
-            path (str): The given input path that might or might not contain the detector name.
-
-        Returns:
-            str: a modified path that contains the detector name.
-        """
-        if path.startswith("lp://"):  # TODO: Move "lp://" to a constant
-            model_name = path[len("lp://") :]
-            model_name_segments = model_name.split("/")
-            if (
-                len(model_name_segments) == 3
-                and self.DETECTOR_NAME not in model_name_segments
-            ):
-                return "lp://" + self.DETECTOR_NAME + "/" + path[len("lp://") :]
-        return path
-
     def gather_output(self, outputs):
 
         instance_pred = outputs["instances"].to("cpu")

--- a/src/layoutparser/models/detectron2/layoutmodel.py
+++ b/src/layoutparser/models/detectron2/layoutmodel.py
@@ -1,6 +1,7 @@
 from typing import Union
 from PIL import Image
 import numpy as np
+import warnings
 
 from .catalog import MODEL_CATALOG, PathManager, LABEL_MAP_CATALOG
 from ..base_layoutmodel import BaseLayoutModel
@@ -30,9 +31,9 @@ class Detectron2LayoutModel(BaseLayoutModel):
             word labels (strings). If the config is from one of the supported
             datasets, Layout Parser will automatically initialize the label_map.
             Defaults to `None`.
-        enforce_cpu(:obj:`bool`, optional):
-            When set to `True`, it will enforce using cpu even if it is on a CUDA
-            available device.
+        device(:obj:`str`, optional):
+            Whether to use cuda or cpu devices. If not set, LayoutParser will
+            automatically determine the device to initialize the models on.
         extra_config (:obj:`list`, optional):
             Extra configuration passed to the Detectron2 model
             configuration. The argument will be used in the `merge_from_list
@@ -57,22 +58,30 @@ class Detectron2LayoutModel(BaseLayoutModel):
         model_path=None,
         label_map=None,
         extra_config=None,
-        enforce_cpu=False,
-        device=None
+        enforce_cpu=None,
+        device=None,
     ):
+
+        if enforce_cpu is not None:
+            warnings.warn(
+                "Setting enforce_cpu is deprecated. Please set `device` instead.",
+                DeprecationWarning,
+            )
 
         if extra_config is None:
             extra_config = []
 
-        config_path, model_path = self.config_parser(config_path, model_path, allow_empty_path=True)
+        config_path, model_path = self.config_parser(
+            config_path, model_path, allow_empty_path=True
+        )
         config_path = PathManager.get_local_path(config_path)
 
         cfg = detectron2.config.get_cfg()
         cfg.merge_from_file(config_path)
         cfg.merge_from_list(extra_config)
-        
+
         if model_path is not None:
-            model_path = PathManager.get_local_path(model_path) 
+            model_path = PathManager.get_local_path(model_path)
             # Because it will be forwarded to the detectron2 paths
             cfg.MODEL.WEIGHTS = model_path
 

--- a/src/layoutparser/models/effdet/catalog.py
+++ b/src/layoutparser/models/effdet/catalog.py
@@ -22,6 +22,9 @@ LABEL_MAP_CATALOG = {
         3: "List", 
         4: "Table", 
         5: "Figure"
+    },
+    "MFD": {
+        1: "Equation",
     }
 }
 

--- a/src/layoutparser/models/effdet/layoutmodel.py
+++ b/src/layoutparser/models/effdet/layoutmodel.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union, Dict, Any, Tuple
 from PIL import Image
 import numpy as np
 
-from .catalog import PathManager, LABEL_MAP_CATALOG
+from .catalog import PathManager, LABEL_MAP_CATALOG, MODEL_CATALOG
 from ..base_layoutmodel import BaseLayoutModel
 from ...elements import Rectangle, TextBlock, Layout
 
@@ -91,6 +91,7 @@ class EfficientDetLayoutModel(BaseLayoutModel):
 
     DEPENDENCIES = ["effdet"]
     DETECTOR_NAME = "efficientdet"
+    MODEL_CATALOG = MODEL_CATALOG
 
     DEFAULT_OUTPUT_CONFIDENCE_THRESHOLD = 0.25
 
@@ -129,21 +130,17 @@ class EfficientDetLayoutModel(BaseLayoutModel):
         extra_config: Optional[Dict],
     ):
 
+        config_path, model_path = self.config_parser(config_path, model_path)
+
         if config_path.startswith("lp://"):
             # If it's officially supported by layoutparser
-            dataset_name, model_name = config_path.lstrip("lp://").split("/")[0:2]
+            dataset_name, model_name = config_path.lstrip("lp://").split("/")[1:3]
 
             if label_map is None:
                 label_map = LABEL_MAP_CATALOG[dataset_name]
             num_classes = len(label_map)
 
-            if model_path is None:
-                # Download the models when it model_path is not specified
-                model_path = PathManager.get_local_path(
-                    self._reconstruct_path_with_detector_name(
-                        config_path.replace("config", "weight")
-                    )
-                )
+            model_path = PathManager.get_local_path(model_path)
 
             self.model = create_model(
                 model_name,

--- a/src/layoutparser/models/effdet/layoutmodel.py
+++ b/src/layoutparser/models/effdet/layoutmodel.py
@@ -181,26 +181,6 @@ class EfficientDetLayoutModel(BaseLayoutModel):
         self.config = self.model.config
         self.label_map = label_map if label_map is not None else {}
 
-    def _reconstruct_path_with_detector_name(self, path: str) -> str:
-        """This function will add the detector name (efficientdet) into the
-        lp model config path to get the "canonical" model name.
-
-        Args:
-            path (str): The given input path that might or might not contain the detector name.
-
-        Returns:
-            str: a modified path that contains the detector name.
-        """
-        if path.startswith("lp://"):  # TODO: Move "lp://" to a constant
-            model_name = path[len("lp://") :]
-            model_name_segments = model_name.split("/")
-            if (
-                len(model_name_segments) == 3
-                and self.DETECTOR_NAME not in model_name_segments
-            ):
-                return "lp://" + self.DETECTOR_NAME + "/" + path[len("lp://") :]
-        return path
-
     def detect(self, image: Union["np.ndarray", "Image.Image"]):
 
         image = self.image_loader(image)

--- a/src/layoutparser/models/model_config.py
+++ b/src/layoutparser/models/model_config.py
@@ -87,7 +87,6 @@ def layout_model_config_parser(
     )
 
     parts = config[len(LAYOUT_PARSER_MODEL_PREFIX) :].split("/")
-    print(parts)
     if len(parts) == 4:  # Full format
         backend_name, dataset_name, model_arch, identifier = parts
     elif len(parts) == 3:  # Short format

--- a/src/layoutparser/models/model_config.py
+++ b/src/layoutparser/models/model_config.py
@@ -68,7 +68,7 @@ class LayoutModelConfig:
 def is_lp_layout_model_config_any_format(config: str) -> bool:
     if not config.startswith(LAYOUT_PARSER_MODEL_PREFIX):
         return False
-    if len(config[len(LAYOUT_PARSER_MODEL_PREFIX) :].split("/")) not in [2, 3, 4]:
+    if len(config[len(LAYOUT_PARSER_MODEL_PREFIX) :].split("/")) not in [1, 2, 3, 4]:
         return False
     return True
 
@@ -91,10 +91,23 @@ def layout_model_config_parser(
         backend_name, dataset_name, model_arch, identifier = parts
     elif len(parts) == 3:  # Short format
         assert backend_name != None
-        dataset_name, model_arch, identifier = parts
+        
+        if parts[0] == backend_name:
+            # lp://<backend-name>/<dataset-name>/<identifier>
+            assert model_arch != None
+            _, dataset_name, identifier = parts
+        else:
+            # lp://<dataset-name>/<model-arch>/<identifier>
+            dataset_name, model_arch, identifier = parts
+            
     elif len(parts) == 2:  # brief format
         assert backend_name != None
         assert model_arch != None
+        if parts[0] == backend_name:
+            # lp://<backend-name>/<identifier>    
+            raise ValueError(f"Invalid LP Model Config {config}")
+            
+        # lp://<dataset-name>/<identifier>    
         dataset_name, identifier = parts
     else:
         raise ValueError(f"Invalid LP Model Config {config}")

--- a/src/layoutparser/models/model_config.py
+++ b/src/layoutparser/models/model_config.py
@@ -1,0 +1,108 @@
+"""
+Inside layoutparser, we support the following formats for specifying layout model configs 
+or weights:
+
+1. URL-based formats:
+    - A local path: ~/models/publaynet/path
+    - Link to the models: https://web/url/to/models
+
+2. LayoutParser Based Model/Config Path Formats:
+    - Full format: lp://<backend-name>/<dataset-name>/<model-architecture-name>
+    - Short format: lp://<dataset-name>/<model-architecture-name> 
+    - Brief format: lp://<dataset-name>
+
+For each LayoutParser-based format, you could also add a `config` or `weight` identifier 
+after them: 
+    - Full format: lp://<backend-name>/<dataset-name>/<model-architecture-name>/<config, weight>
+    - Short format: lp://<dataset-name>/<model-architecture-name>/<config, weight> 
+    - Brief format: lp://<dataset-name>/<config, weight>
+"""
+
+from typing import List, OrderedDict, Union, Dict, Any, Tuple, Optional, NamedTuple
+from dataclasses import dataclass
+
+LAYOUT_PARSER_MODEL_PREFIX = "lp://"
+ALLOWED_LAYOUT_MODEL_IDENTIFIER_NAMES = ["config", "weight"]
+
+
+@dataclass
+class LayoutModelConfig:
+
+    backend_name: str
+    dataset_name: str
+    model_arch: str
+    identifier: str
+
+    def __post_init__(self):
+        assert self.identifier in ALLOWED_LAYOUT_MODEL_IDENTIFIER_NAMES
+
+    @property
+    def full(self):
+        return LAYOUT_PARSER_MODEL_PREFIX + "/".join(
+            [self.backend_name, self.dataset_name, self.model_arch, self.identifier]
+        )
+
+    @property
+    def short(self):
+        return LAYOUT_PARSER_MODEL_PREFIX + "/".join(
+            [self.dataset_name, self.model_arch, self.identifier]
+        )
+
+    @property
+    def brief(self):
+        return LAYOUT_PARSER_MODEL_PREFIX + "/".join([self.dataset_name, self.model_arch])
+
+    def dual(self):
+        for identifier in ALLOWED_LAYOUT_MODEL_IDENTIFIER_NAMES:
+            if identifier != self.identifier:
+                break
+
+        return self.__class__(
+            backend_name=self.backend_name,
+            dataset_name=self.dataset_name,
+            model_arch=self.model_arch,
+            identifier=identifier,
+        )
+
+
+def is_lp_layout_model_config_any_format(config: str) -> bool:
+    if not config.startswith(LAYOUT_PARSER_MODEL_PREFIX):
+        return False
+    if len(config[len(LAYOUT_PARSER_MODEL_PREFIX) :].split("/")) not in [2, 3, 4]:
+        return False
+    return True
+
+
+def add_identifier_for_config(config: str, identifier: str) -> str:
+    return config.rstrip("/").rstrip(f"/{identifier}") + f"/{identifier}"
+
+
+def layout_model_config_parser(
+    config, backend_name=None, model_arch=None
+) -> LayoutModelConfig:
+
+    assert config.split("/")[-1] in ALLOWED_LAYOUT_MODEL_IDENTIFIER_NAMES, (
+        f"The input config {config} does not contain identifier information."
+        f"Consider run `config = add_identifier_for_config(config, identifier)` first."
+    )
+
+    parts = config[len(LAYOUT_PARSER_MODEL_PREFIX) :].split("/")
+    print(parts)
+    if len(parts) == 4:  # Full format
+        backend_name, dataset_name, model_arch, identifier = parts
+    elif len(parts) == 3:  # Short format
+        assert backend_name != None
+        dataset_name, model_arch, identifier = parts
+    elif len(parts) == 2:  # brief format
+        assert backend_name != None
+        assert model_arch != None
+        dataset_name, identifier = parts
+    else:
+        raise ValueError(f"Invalid LP Model Config {config}")
+
+    return LayoutModelConfig(
+        backend_name=backend_name,
+        dataset_name=dataset_name,
+        model_arch=model_arch,
+        identifier=identifier,
+    )

--- a/src/layoutparser/models/paddledetection/catalog.py
+++ b/src/layoutparser/models/paddledetection/catalog.py
@@ -12,13 +12,14 @@ from iopath.common.download import download
 
 from ..base_catalog import PathManager
 
-CONFIG_CATALOG = {
+MODEL_CATALOG = {
     "PubLayNet": {
-        "ppyolov2_r50vd_dcn_365e_publaynet": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_publaynet.tar",
+        "ppyolov2_r50vd_dcn_365e": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_publaynet.tar",
     },
     "TableBank": {
-        "ppyolov2_r50vd_dcn_365e_tableBank_word": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_tableBank_word.tar",
-        "ppyolov2_r50vd_dcn_365e_tableBank_latex": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_tableBank_latex.tar",
+        "ppyolov2_r50vd_dcn_365e": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_tableBank_word.tar",
+        # "ppyolov2_r50vd_dcn_365e_tableBank_latex": "https://paddle-model-ecology.bj.bcebos.com/model/layout-parser/ppyolov2_r50vd_dcn_365e_tableBank_latex.tar",
+        # TODO: Train a single tablebank model for paddlepaddle
     },
 }
 
@@ -184,8 +185,8 @@ class LayoutParserPaddleModelHandler(PathHandler):
         model_name = path[len(self.PREFIX) :]
         dataset_name, *model_name, data_type = model_name.split("/")
 
-        if data_type == "config":
-            model_url = CONFIG_CATALOG[dataset_name]["/".join(model_name)]
+        if data_type == "weight":
+            model_url = MODEL_CATALOG[dataset_name]["/".join(model_name)]
         else:
             raise ValueError(f"Unknown data_type {data_type}")
         return PathManager.get_local_path(model_url, **kwargs)

--- a/src/layoutparser/models/paddledetection/layoutmodel.py
+++ b/src/layoutparser/models/paddledetection/layoutmodel.py
@@ -132,34 +132,6 @@ class PaddleDetectionLayoutModel(BaseLayoutModel):
         )
         self.label_map = label_map
 
-    def _reconstruct_path_with_detector_name(self, path: str) -> str:
-        """This function will add the detector name (paddledetection) into the
-        lp model config path to get the "canonical" model name.
-
-        For example,
-        for a given config_path `lp://PubLayNet/ppyolov2_r50vd_dcn_365e_publaynet/config`,it will
-        transform it into `lp://paddledetection/PubLayNet/ppyolov2_r50vd_dcn_365e_publaynet/config`.
-        However, if the config_path already contains the detector name, we won't change it.
-
-        This function is a general step to support multiple backends in the layout-parser
-        library.
-
-        Args:
-            path (str): The given input path that might or might not contain the detector name.
-
-        Returns:
-            str: a modified path that contains the detector name.
-        """
-        if path.startswith("lp://"):  # TODO: Move "lp://" to a constant
-            model_name = path[len("lp://") :]
-            model_name_segments = model_name.split("/")
-            if (
-                len(model_name_segments) == 3
-                and self.DETECTOR_NAME not in model_name_segments
-            ):
-                return "lp://" + self.DETECTOR_NAME + "/" + path[len("lp://") :]
-        return path
-
     def load_predictor(
         self,
         model_dir,

--- a/src/layoutparser/visualization.py
+++ b/src/layoutparser/visualization.py
@@ -2,7 +2,6 @@ from typing import List, Union, Dict, Any, Tuple
 import functools
 import os
 import sys
-import warnings
 from itertools import cycle
 
 import numpy as np

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,9 +17,8 @@ ALL_DETECTRON2_MODEL_CONFIGS = [
 ]
 
 ALL_PADDLEDETECTION_MODEL_CONFIGS = [
-    "lp://PubLayNet/ppyolov2_r50vd_dcn_365e_publaynet/config",
-    "lp://TableBank/ppyolov2_r50vd_dcn_365e_tableBank_word/config",
-    "lp://TableBank/ppyolov2_r50vd_dcn_365e_tableBank_latex/config",
+    "lp://PubLayNet/ppyolov2_r50vd_dcn_365e/config",
+    "lp://TableBank/ppyolov2_r50vd_dcn_365e/config",
 ]
 
 ALL_EFFDET_MODEL_CONFIGS = [
@@ -44,7 +43,7 @@ def test_Detectron2Model(is_large_scale=False):
         layout = model.detect(image)
         
     # Test in enforce CPU mode
-    model = Detectron2LayoutModel("tests/fixtures/model/config.yml", enforce_cpu=True)
+    model = Detectron2LayoutModel("tests/fixtures/model/config.yml")
     image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
     layout = model.detect(image)
     
@@ -72,12 +71,12 @@ def test_PaddleDetectionModel(is_large_scale=False):
             image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
             layout = model.detect(image)
     else:
-        model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e_publaynet/config")
+        model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e/config")
         image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
         layout = model.detect(image)
         
     # Test in enforce CPU mode
-    model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e_publaynet/config", enforce_cpu=True)
+    model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e/config", enforce_cpu=True)
     image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
     layout = model.detect(image)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,8 @@
+import pytest
+import cv2
+
 from layoutparser import load_json
 from layoutparser.models import *
-import cv2
 
 ALL_DETECTRON2_MODEL_CONFIGS = [
     "lp://PrimaLayout/mask_rcnn_R_50_FPN_3x/config",
@@ -28,6 +30,42 @@ ALL_EFFDET_MODEL_CONFIGS = [
     "lp://MFD/tf_efficientdet_d1/config",
 ]
 
+
+def _construct_valid_config_variations(config, backend_name):
+    dataset_name, arch_name, identifier = config[len("lp://") :].split("/")
+    return [
+        "lp://" + "/".join([backend_name, dataset_name, arch_name, identifier]),
+        "lp://" + "/".join([backend_name, dataset_name, arch_name]),
+        "lp://" + "/".join([backend_name, dataset_name]),
+        "lp://" + "/".join([dataset_name, arch_name, identifier]),
+        "lp://" + "/".join([dataset_name, arch_name]),
+        "lp://" + "/".join([dataset_name]),
+    ]
+
+
+def _construct_invalid_config_variations(config, backend_name):
+    dataset_name, arch_name, identifier = config[len("lp://") :].split("/")
+    return [
+        "lp://" + "/".join([backend_name]),
+    ]
+
+
+def _single_config_test_pipeline(TestLayoutModel, base_config):
+    for config in _construct_valid_config_variations(
+        base_config, TestLayoutModel.DETECTOR_NAME
+    ):
+        model = TestLayoutModel(config)
+        image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
+        layout = model.detect(image)
+        del model
+
+    for config in _construct_invalid_config_variations(
+        base_config, TestLayoutModel.DETECTOR_NAME
+    ):
+        with pytest.raises(ValueError):
+            model = TestLayoutModel(config)
+
+
 def test_Detectron2Model(is_large_scale=False):
 
     if is_large_scale:
@@ -38,31 +76,36 @@ def test_Detectron2Model(is_large_scale=False):
             image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
             layout = model.detect(image)
     else:
-        model = Detectron2LayoutModel("tests/fixtures/model/config.yml")
-        image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
-        layout = model.detect(image)
-        
+        _single_config_test_pipeline(
+            Detectron2LayoutModel, ALL_DETECTRON2_MODEL_CONFIGS[0]
+        )
     # Test in enforce CPU mode
     model = Detectron2LayoutModel("tests/fixtures/model/config.yml")
     image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
     layout = model.detect(image)
-    
+
+
 def test_Detectron2Model_version_compatibility(enabled=False):
-    
+
     if enabled:
         model = Detectron2LayoutModel(
             config_path="lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config",
             extra_config=[
-                "MODEL.ROI_HEADS.SCORE_THRESH_TEST", 0.85,
-                "MODEL.ROI_HEADS.NMS_THRESH_TEST", 0.75,
+                "MODEL.ROI_HEADS.SCORE_THRESH_TEST",
+                0.85,
+                "MODEL.ROI_HEADS.NMS_THRESH_TEST",
+                0.75,
             ],
         )
         image = cv2.imread("tests/fixtures/model/layout_detection_reference.jpg")
         layout = model.detect(image)
-        assert load_json("tests/fixtures/model/layout_detection_reference.json") == layout
+        assert (
+            load_json("tests/fixtures/model/layout_detection_reference.json") == layout
+        )
+
 
 def test_PaddleDetectionModel(is_large_scale=False):
-    """ test PaddleDetection model """
+    """test PaddleDetection model"""
     if is_large_scale:
 
         for config in ALL_PADDLEDETECTION_MODEL_CONFIGS:
@@ -71,14 +114,10 @@ def test_PaddleDetectionModel(is_large_scale=False):
             image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
             layout = model.detect(image)
     else:
-        model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e/config")
-        image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
-        layout = model.detect(image)
-        
-    # Test in enforce CPU mode
-    model = PaddleDetectionLayoutModel("lp://PubLayNet/ppyolov2_r50vd_dcn_365e/config", enforce_cpu=True)
-    image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
-    layout = model.detect(image)
+        _single_config_test_pipeline(
+            PaddleDetectionLayoutModel, ALL_PADDLEDETECTION_MODEL_CONFIGS[0]
+        )
+
 
 def test_EffDetModel(is_large_scale=False):
 
@@ -90,6 +129,6 @@ def test_EffDetModel(is_large_scale=False):
             image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
             layout = model.detect(image)
     else:
-        model = EfficientDetLayoutModel("lp://PubLayNet/tf_efficientdet_d0/config")
-        image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
-        layout = model.detect(image)
+        _single_config_test_pipeline(
+            EfficientDetLayoutModel, ALL_EFFDET_MODEL_CONFIGS[0]
+        )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -30,6 +30,11 @@ ALL_EFFDET_MODEL_CONFIGS = [
     "lp://MFD/tf_efficientdet_d1/config",
 ]
 
+AUTOMODEL_CONFIGS = [
+    "lp://detectron2/PubLayNet/faster_rcnn_R_50_FPN_3x/config",
+    "lp://paddledetection/PubLayNet/ppyolov2_r50vd_dcn_365e/config",
+    "lp://efficientdet/PubLayNet/tf_efficientdet_d0/config",
+]
 
 def _construct_valid_config_variations(config, backend_name):
     dataset_name, arch_name, identifier = config[len("lp://") :].split("/")
@@ -132,3 +137,9 @@ def test_EffDetModel(is_large_scale=False):
         _single_config_test_pipeline(
             EfficientDetLayoutModel, ALL_EFFDET_MODEL_CONFIGS[0]
         )
+
+def test_AutoModel():
+    for config in AUTOMODEL_CONFIGS:
+        model = AutoLayoutModel(config)
+        image = cv2.imread("tests/fixtures/model/test_model_image.jpg")
+        layout = model.detect(image)


### PR DESCRIPTION
After this update, layout-parser will provide more flexible ways of initializing the models and specifying the model configs:

1. New `AutoLayoutModel` class that supports the convenient loading of the models from different backends. There are several different ways of specifying the models: 
    1. `AutoLayoutModel("lp://<detector-name>/<dataset-name>/<model-arch>/config")` will create a model of the `<detector-name>` backed using the `"lp://<dataset-name>/<model-arch>/config"`. 
    2. `AutoLayoutModel("lp://<detector-name>/<dataset-name>/<model-arch>")` is more concise: it works the same as the command above, while you don't need to specify the `config` in the input. 
    3. `AutoLayoutModel("lp://<detector-name>/<dataset-name>")` will automatically find the corresponding `<model-arch>` for you as long as there are models trained for this dataset. 
    
    Here are some examples: 
    1. `lp.AutoLayoutModel("lp://efficientdet/PubLayNet/tf_efficientdet_d0/config")`
    2. `lp.AutoLayoutModel("lp://efficientdet/PubLayNet/tf_efficientdet_d0")`
    3. `lp.AutoLayoutModel("lp://efficientdet/PubLayNet")`

2. Similar level of flexibility is also supported for existing `LayoutModel`s: 
    1. `lp.XXLayoutModel("lp://<dataset-name>/<model-arch>/config")`
    2. `lp.XXLayoutModel("lp://<dataset-name>/<model-arch>")`
    3. `lp.XXLayoutModel("lp://<dataset-name>")`