### PR TITLE
Better Visualization Functions 

### DIFF
--- a/src/layoutparser/visualization.py
+++ b/src/layoutparser/visualization.py
@@ -323,7 +323,8 @@ def draw_box(
             else color_map.get(ele.type, DEFAULT_OUTLINE_COLOR)
         )
 
-        _draw_box_outline_on_handler(draw, ele, outline_color, box_width)
+        if box_width > 0:
+            _draw_box_outline_on_handler(draw, ele, outline_color, box_width)
 
         _draw_transparent_box_on_handler(draw, ele, outline_color, box_alpha)
 

--- a/src/layoutparser/visualization.py
+++ b/src/layoutparser/visualization.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union, Dict, Any, Tuple
+from typing import List, Optional, Union, Dict, Any, Tuple, Dict
 import functools
 import os
 import sys
@@ -223,19 +223,19 @@ def draw_transparent_box(
 
 @image_loader
 def draw_box(
-    canvas,
-    layout,
-    box_width=None,
-    box_alpha=0,
-    color_map=None,
-    colors=None,
-    show_element_id=False,
-    show_element_type=False,
-    id_font_size=None,
-    id_font_path=None,
-    id_text_color=None,
-    id_text_background_color=None,
-    id_text_background_alpha=1,
+    canvas: Image.Image,
+    layout: Layout,
+    box_width: Optional[int] = None,
+    box_alpha: Optional[float] = 0,
+    box_color: Optional[List] = None,
+    color_map: Optional[Dict] = None,
+    show_element_id: bool = False,
+    show_element_type: bool = False,
+    id_font_size: Optional[int] = None,
+    id_font_path: Optional[str] = None,
+    id_text_color: Optional[str] = None,
+    id_text_background_color: Optional[str] = None,
+    id_text_background_alpha: Optional[float] = 1,
 ):
     """Draw the layout region on the input canvas(image).
 
@@ -253,17 +253,17 @@ def draw_box(
             A float range from 0 to 1. Set to change the alpha of the
             drawn layout box.
             Defaults to 0 - the layout box will be fully transparent.
+        box_color (list, optional):
+            A list-like object of colors, e.g., `['red', 'green', 'blue']`,
+            of the same length as the number of blocks in the layout input/
+            Defaults to None. When `box_color` is set, it will override the
+            `color_map`.
         color_map (dict, optional):
             A map from `block.type` to the colors, e.g., `{1: 'red'}`.
             You can set it to `{}` to use only the
             :const:`DEFAULT_OUTLINE_COLOR` for the outlines.
             Defaults to None, when a color palette is is automatically
             created based on the input layout.
-        colors (list, optional):
-            A list-like object of colors, e.g., `['red', 'green', 'blue']`,
-            of the same length as the number of blocks in the layout input/
-            Defaults to None. When `colors` is set, it will override the
-            `color_map`.
         show_element_id (bool, optional):
             Whether to display `block.id` on the top-left corner of
             the block.
@@ -314,23 +314,23 @@ def draw_box(
     if show_element_id or show_element_type:
         font_obj = _create_font_object(id_font_size, id_font_path)
 
-    if colors is not None:
-        if len(colors) != len(layout):
+    if box_color is not None:
+        if len(box_color) != len(layout):
             raise ValueError(
-                f"The number of colors {len(colors)} is not equal to the number of blocks {len(layout)}"
+                f"The number of colors {len(box_color)} is not equal to the number of blocks {len(layout)}"
             )
     else:
         if color_map is None:
             all_types = set([b.type for b in layout if hasattr(b, "type")])
             color_map = _create_color_palette(all_types)
-        colors = [
+        box_color = [
             DEFAULT_OUTLINE_COLOR
             if not isinstance(ele, TextBlock)
             else color_map.get(ele.type, DEFAULT_OUTLINE_COLOR)
             for ele in layout
         ]
 
-    for idx, (ele, color) in enumerate(zip(layout, colors)):
+    for idx, (ele, color) in enumerate(zip(layout, box_color)):
 
         if isinstance(ele, Interval):
             ele = ele.put_on_canvas(canvas)
@@ -378,18 +378,18 @@ def draw_box(
 def draw_text(
     canvas,
     layout,
-    arrangement="lr",
-    font_size=None,
-    font_path=None,
-    text_color=None,
-    text_background_color=None,
-    text_background_alpha=1,
-    vertical_text=False,
-    with_box_on_text=False,
-    text_box_width=None,
-    text_box_color=None,
-    text_box_alpha=0,
-    with_layout=False,
+    arrangement: str = "lr",
+    font_size: Optional[int] = None,
+    font_path: Optional[str] = None,
+    text_color: Optional[str] = None,
+    text_background_color: Optional[str] = None,
+    text_background_alpha: Optional[float] = None,
+    vertical_text: bool = False,
+    with_box_on_text: bool = False,
+    text_box_width: Optional[int] = None,
+    text_box_color: Optional[str] = None,
+    text_box_alpha: Optional[float] = None,
+    with_layout: bool = False,
     **kwargs,
 ):
     """Draw the (detected) text in the `layout` according to

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -44,12 +44,12 @@ def test_viz():
     draw_text(image, layout)
 
     # Test colors
-    draw_box(image, layout, colors=["red", "green", "blue"])
-    draw_text(image, layout, colors=["red", "green", "blue"])
+    draw_box(image, layout, box_color=["red", "green", "blue"])
+    draw_text(image, layout, box_color=["red", "green", "blue"])
     with pytest.raises(ValueError):
-        draw_box(image, layout, colors=["red", "green", "blue", "yellow"])
+        draw_box(image, layout, box_color=["red", "green", "blue", "yellow"])
     with pytest.raises(ValueError):
-        draw_text(image, layout, colors=["red", "green", "blue", "yellow"], with_layout=True)
+        draw_text(image, layout, box_color=["red", "green", "blue", "yellow"], with_layout=True)
 
     for idx, level in enumerate(
         [

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -45,11 +45,40 @@ def test_viz():
 
     # Test colors
     draw_box(image, layout, box_color=["red", "green", "blue"])
+    draw_box(image, layout, box_color="red")
+
     draw_text(image, layout, box_color=["red", "green", "blue"])
     with pytest.raises(ValueError):
         draw_box(image, layout, box_color=["red", "green", "blue", "yellow"])
     with pytest.raises(ValueError):
-        draw_text(image, layout, box_color=["red", "green", "blue", "yellow"], with_layout=True)
+        draw_text(
+            image,
+            layout,
+            box_color=["red", "green", "blue", "yellow"],
+            with_layout=True,
+        )
+
+    # Test alphas
+    draw_box(image, layout, box_alpha=0)
+    draw_box(image, layout, box_alpha=[0.1, 0.2, 0.3])
+    with pytest.raises(ValueError):
+        draw_box(image, layout, box_color=[0.1, 0.2, 0.3, 0.5])
+    with pytest.raises(ValueError):
+        draw_box(image, layout, box_color=[0.1, 0.2, 0.3, 1.5])
+
+    # Test widths
+    draw_box(image, layout, box_width=1)
+    draw_box(image, layout, box_width=[1, 2, 3])
+    with pytest.raises(ValueError):
+        draw_box(image, layout, box_width=[1, 2, 3, 4])
+
+    draw_box(
+        image,
+        layout,
+        box_alpha=[0.1, 0.2, 0.3],
+        box_width=[1, 2, 3],
+        box_color=["red", "green", "blue"],
+    )
 
     for idx, level in enumerate(
         [

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from layoutparser.elements import *
 from layoutparser.ocr import *
 from layoutparser.visualization import *
@@ -30,27 +32,24 @@ def test_viz():
     draw_box(image, Layout([]))
     draw_text(image, Layout([]))
 
-    draw_box(
-        image,
-        Layout(
-            [
-                Interval(0, 10, axis="x"),
-                Rectangle(0, 50, 100, 80),
-                Quadrilateral(np.array([[10, 10], [30, 40], [90, 40], [10, 20]])),
-            ]
-        ),
+    layout = Layout(
+        [
+            Interval(0, 10, axis="x"),
+            Rectangle(0, 50, 100, 80),
+            Quadrilateral(np.array([[10, 10], [30, 40], [90, 40], [10, 20]])),
+        ]
     )
 
-    draw_text(
-        image,
-        Layout(
-            [
-                Interval(0, 10, axis="x"),
-                Rectangle(0, 50, 100, 80),
-                Quadrilateral(np.array([[10, 10], [30, 40], [90, 40], [10, 20]])),
-            ]
-        ),
-    )
+    draw_box(image, layout)
+    draw_text(image, layout)
+
+    # Test colors
+    draw_box(image, layout, colors=["red", "green", "blue"])
+    draw_text(image, layout, colors=["red", "green", "blue"])
+    with pytest.raises(ValueError):
+        draw_box(image, layout, colors=["red", "green", "blue", "yellow"])
+    with pytest.raises(ValueError):
+        draw_text(image, layout, colors=["red", "green", "blue", "yellow"], with_layout=True)
 
     for idx, level in enumerate(
         [
@@ -82,7 +81,7 @@ def test_viz():
             show_element_id=True,
             id_font_size=8,
             box_alpha=0.25,
-            id_text_background_alpha=0.25
+            id_text_background_alpha=0.25,
         )
 
         draw_box(image, layout)


### PR DESCRIPTION
1. Not drawing the box outlines when setting `box_width=0`. For example, 

    ```python
    from PIL import Image
    import layoutparser as lp

    image = Image.new('RGB', (50,50), color='white')
    lp.draw_box(image, [lp.Rectangle(10, 10, 40, 40)], box_width=0)
    ```

    Previously, it will draw a box ![image](https://user-images.githubusercontent.com/22512825/161409249-d2cad857-d086-4fdf-ba55-4a52a03d29ce.png). 

2. Allowing setting `box_color` in `draw_box`: 
    1. directly setting `box_color`:
        ```python
        from PIL import Image
        import layoutparser as lp

        image = Image.new('RGB', (50,50), color='white')

        lp.draw_box(image, 
                    [lp.TextBlock(lp.Rectangle(10, 10, 20, 20), type='a'), 
                    lp.TextBlock(lp.Rectangle(30, 30, 45, 45), type='b'),] ,
                    box_color=['black', 'red'])
        ```
        ![image](https://user-images.githubusercontent.com/22512825/161409805-f5d78ee4-ce96-420b-b7ba-587474b2e9db.png)

    2. overriding `color_map`:
        ```python
        lp.draw_box(image, 
                    [lp.TextBlock(lp.Rectangle(10, 10, 20, 20), type='a'), 
                    lp.TextBlock(lp.Rectangle(30, 30, 45, 45), type='b'),] ,
                    color_map={'a':'black', 'b':'blue'}, box_color=['black', 'red'])
        ```
        ![image](https://user-images.githubusercontent.com/22512825/161409826-ae204520-b08e-45fa-89f8-194d696b8dc2.png)
3. Setting `box_color`, `box_alpha`, and `box_width` for each objects: 
    ```python
    from PIL import Image
    import layoutparser as lp

    image = Image.new('RGB', (50,50), color='white')
    lp.draw_box(image, 
                [lp.TextBlock(lp.Rectangle(10, 10, 20, 20), type='a'), 
                lp.TextBlock(lp.Rectangle(30, 30, 45, 45), type='b'),] ,
                box_color=['black', 'red'], 
                box_alpha=[0.1, 0.5], 
                box_width=[2,4])
    ```
    ![image](https://user-images.githubusercontent.com/22512825/161410663-558fdd36-2d84-49e7-8382-2b4e41cd9c18.png)
