### PR TITLE
Fix: add one import for type hints

### DIFF
--- a/src/layoutparser/io/pdf.py
+++ b/src/layoutparser/io/pdf.py
@@ -16,6 +16,7 @@ from typing import List, Union, Optional, Dict, Tuple
 
 import pdfplumber
 import pandas as pd
+from PIL import Image
 
 from ..elements import Layout
 from .basic import load_dataframe


### PR DESCRIPTION
At `layoutparser.io`, the type hint `Image.Image` is used, but it is not imported.