### PR TITLE
REFAC: Specify type of blocks arg in Layout ctor

### DIFF
--- a/src/layoutparser/elements/layout.py
+++ b/src/layoutparser/elements/layout.py
@@ -46,7 +46,7 @@ class Layout(MutableSequence):
             Defaults to None.
     """
 
-    def __init__(self, blocks: Optional[List] = None, *, page_data: Dict = None):
+    def __init__(self, blocks: Optional[List["Layout"]] = None, *, page_data: Dict = None):
 
         if not (
             (blocks is None)


### PR DESCRIPTION
Update constructor to specify the type of input parameter in the `blocks` argument to Layout class