### PR TITLE
Update index.rst allow for proper loading of Detectron2LayoutModel

### DIFF
--- a/docs/example/deep_layout_parsing/index.rst
+++ b/docs/example/deep_layout_parsing/index.rst
@@ -29,7 +29,7 @@ Use Layout Models to detect complex layout
 
 .. code:: python
 
-    model = lp.Detectron2LayoutModel('lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config', 
+    model = lp.models.Detectron2LayoutModel('lp://PubLayNet/faster_rcnn_R_50_FPN_3x/config', 
                                      extra_config=["MODEL.ROI_HEADS.SCORE_THRESH_TEST", 0.8],
                                      label_map={0: "Text", 1: "Title", 2: "List", 3:"Table", 4:"Figure"})
         # Load the deep layout model from the layoutparser API 


### PR DESCRIPTION
Currently using the `lp.Detectron2LayoutModel` leads to an error. Correcting this to be `lp.models.Detectron2LayoutModel`